### PR TITLE
Adjust command signature to support binary input

### DIFF
--- a/src/hasher.rs
+++ b/src/hasher.rs
@@ -77,6 +77,7 @@ where
     Signature::build(self.name())
       .category(Category::Hash)
       .input_output_types(vec![
+        (Type::Binary, Type::Any),
         (Type::String, Type::Any),
         (Type::table(), Type::table()),
         (Type::record(), Type::record()),


### PR DESCRIPTION
The hash generation code already had provisions for binary input, but the command signature lacked the appropriate input type. This PR adjusts the signature of each hashing command, allowing for raw binary input to be supplied as well.