### PR TITLE
Update to support Nushell 0.103.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -215,9 +215,9 @@ checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
 
 [[package]]
 name = "bytesize"
-version = "1.3.0"
+version = "1.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3e368af43e418a04d52505cf3dbc23dda4e3407ae2fa99fd0e4f308ce546acc"
+checksum = "2e93abca9e28e0a1b9877922aacb20576e05d4679ffa78c3d6dc22a26a216659"
 
 [[package]]
 name = "cc"
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f8b18cce2fde91d9213904b89c1a32e82216b94bbad32deeb0c2bd06b5740bf"
+checksum = "b5e3fadfe7bf3383778c596df0bd11c166e8c363aa64133269c0ff695086c1d2"
 dependencies = [
  "indexmap",
  "miette",
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e07ee0db78cf27c232baaec1d009bc3224e44f83cc03ec3dd5fad208652f8c"
+checksum = "8cea93e3f189c944a246221d7c8ed8e57b23379bf9bb0d31ea7964ff2b56020d"
 dependencies = [
  "itertools",
  "nu-engine",
@@ -931,12 +931,12 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2316ae007dbd5485cc7e717154423380acabf933bbe7b3bb8b2f7f1c91ccc962"
+checksum = "8f1f5198366892552a9a827a61a27e31543a0827c55ccfb6bf060489cec80d25"
 dependencies = [
  "heck",
- "proc-macro-error",
+ "proc-macro-error2",
  "proc-macro2",
  "quote",
  "syn",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c683ba1257530c31ef04c9db61dd03873d5cd6e342ace2ea979b83ebb5facbb0"
+checksum = "0cb715bb4c18e4259d21c5b710f04f7190c9803211e2a0baa31ec3a5841daa56"
 dependencies = [
  "log",
  "nu-glob",
@@ -957,15 +957,18 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca39e05b7e710701b4a979053449c54c68418319e55bcf8cff5d220b7b7bc916"
+checksum = "904fa576593ed75439eec561f62824bbe55f4a05f1c8239309a939d43e0ad704"
+dependencies = [
+ "nu-protocol",
+]
 
 [[package]]
 name = "nu-parser"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3a4bd0ed46cccca3851b55aa25244e92787f5378dff4acefebf179579c9d238"
+checksum = "daac6d76c123d2534bcbc67ed065c4a78a54cf034e09332ed648a85339c11f91"
 dependencies = [
  "bytesize",
  "chrono",
@@ -981,9 +984,9 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b34402c223280f2a12b40562c92d5e39e66dbcf8e63d984b788758e67bfc1fa"
+checksum = "e6e3a55f26e42d1f98fbb4f41fa4fcc7dee1f61f13c5eabda5ca90e78825b2fa"
 dependencies = [
  "dirs",
  "omnipath",
@@ -993,9 +996,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42961e81fcd9fc25498d79f6a54c120d4c3d14d30bde5aaa16cba13ced15878e"
+checksum = "5f35f2290c077441edfde50745b501ba5ffad11217d5d01168cf1ab1b0e4c03d"
 dependencies = [
  "log",
  "nix",
@@ -1009,9 +1012,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed8f3991be99d14ac082bf7fe6f977959d5239b39f5d1ae570d8be08ef893cf5"
+checksum = "5ba6f1d1c7f6ca9852c26e8e65a0f530b8fa3a1237a6c62de089ccaf6c1645fe"
 dependencies = [
  "interprocess",
  "log",
@@ -1025,9 +1028,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a98a6d6ad9f20f805508c1d7cc31a21474e6fd508fe0199836139bb7297cd7c"
+checksum = "edc79cff665e4434153c97bd7065608f6649cf3a45cb1576d39a58a111c87c9f"
 dependencies = [
  "log",
  "nu-engine",
@@ -1042,9 +1045,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cacf325471dbea88c6c7db60476025906b9ba88447f4ba981de70df068647061"
+checksum = "88bef165a59909561b349fb3eda7e16afae8f8d06d6c99527b4545c086b51f87"
 dependencies = [
  "nu-protocol",
  "nu-utils",
@@ -1056,9 +1059,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "12bd2970d834e2577b627194db4ceff43c886559b56287bafb28d0f1f9233695"
+checksum = "91b913effb3fc1b17338a9d3dacddd81ec907a65c94fbd050685366d60d4a773"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -1074,9 +1077,9 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3054343abc3428da886970f7fe6feee895a96da0323497b61bccf700fed4d265"
+checksum = "ca35b5860d171e8e0994d42373f62fc99fb7a0b205e5d8a38897e2869d5f6ab7"
 dependencies = [
  "brotli",
  "bytes",
@@ -1101,6 +1104,8 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "strum",
+ "strum_macros",
  "thiserror 2.0.11",
  "typetag",
  "web-time",
@@ -1109,9 +1114,9 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2588df6916f3b441cfd88babdcbe24e31a04dd4b492e7a30b4f983495fdb0926"
+checksum = "70bb9b1c59acd274bd36b4879e1e03491a3ee2f24689a9070c66fbd8aed23b27"
 dependencies = [
  "chrono",
  "itertools",
@@ -1129,9 +1134,9 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.102.0"
+version = "0.103.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5929f17bc53de1a081c18b6ce968e41f9ef8cf0c1e0cf9276ed72749a653475"
+checksum = "2f01345a3c94f75397020250286c536e1b306cb714b2931c1a1c9a3318254793"
 dependencies = [
  "crossterm",
  "crossterm_winapi",
@@ -1291,26 +1296,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-error"
-version = "1.0.4"
+name = "proc-macro-error-attr2"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
 dependencies = [
- "proc-macro-error-attr",
  "proc-macro2",
  "quote",
- "version_check",
 ]
 
 [[package]]
-name = "proc-macro-error-attr"
-version = "1.0.4"
+name = "proc-macro-error2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
 dependencies = [
+ "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "version_check",
+ "syn",
 ]
 
 [[package]]
@@ -1708,6 +1712,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
 dependencies = [
  "vte",
+]
+
+[[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ default = [
 ]
 
 [dependencies]
-nu-cmd-base = "0.102.0"
-nu-plugin = "0.102.0"
-nu-protocol = "0.102.0"
+nu-cmd-base = "0.103.0"
+nu-plugin = "0.103.0"
+nu-protocol = "0.103.0"
 digest = "0.10.7"
 ascon-hash = { version = "0.2.0", optional = true }
 belt-hash = { version = "0.1.1", optional = true }
@@ -88,7 +88,7 @@ tiger = { version = "0.2.1", optional = true }
 whirlpool = { version = "0.10.4", optional = true }
 
 [dev-dependencies]
-nu-plugin-test-support = "0.102.0"
+nu-plugin-test-support = "0.103.0"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Bumped crate dependencies to 0.103.0. Tested that the crate could build, be added and loaded by Nushell as a plugin. All work as expected.