### PR TITLE
update to support Nushell 0.104.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -608,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -646,9 +646,9 @@ checksum = "7655c9839580ee829dfacba1d1278c2b7883e50a277ff7541299489d6bdfdc45"
 
 [[package]]
 name = "is_debug"
-version = "1.0.2"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8ea828c9d6638a5bd3d8b14e37502b4d56cae910ccf8a5b7f51c7a0eb1d0508"
+checksum = "1fe266d2e243c931d8190177f20bf7f24eed45e96f39e87dc49a27b32d12d407"
 
 [[package]]
 name = "itertools"
@@ -903,9 +903,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-base"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5e3fadfe7bf3383778c596df0bd11c166e8c363aa64133269c0ff695086c1d2"
+checksum = "1ae53525607e64c6c51ca3f217cd94d793f2553e728c0e0c38ac7daa1066dd96"
 dependencies = [
  "indexmap",
  "miette",
@@ -917,9 +917,9 @@ dependencies = [
 
 [[package]]
 name = "nu-cmd-lang"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8cea93e3f189c944a246221d7c8ed8e57b23379bf9bb0d31ea7964ff2b56020d"
+checksum = "e66adfeda88f8e27bcb25d068d9e6e8b3a94c2bf988a9c30e8e3b2045867aefe"
 dependencies = [
  "itertools",
  "nu-engine",
@@ -931,9 +931,9 @@ dependencies = [
 
 [[package]]
 name = "nu-derive-value"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f1f5198366892552a9a827a61a27e31543a0827c55ccfb6bf060489cec80d25"
+checksum = "5fd0d8e358b6440d01fe4e617f180aea826bade72efb54f5dc1c22e0e8038b6f"
 dependencies = [
  "heck",
  "proc-macro-error2",
@@ -944,9 +944,9 @@ dependencies = [
 
 [[package]]
 name = "nu-engine"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cb715bb4c18e4259d21c5b710f04f7190c9803211e2a0baa31ec3a5841daa56"
+checksum = "0c2b01483e3d09460375f0c0da7a83b6dc26fb319ca09c55d0665087b2d587c7"
 dependencies = [
  "log",
  "nu-glob",
@@ -957,18 +957,15 @@ dependencies = [
 
 [[package]]
 name = "nu-glob"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "904fa576593ed75439eec561f62824bbe55f4a05f1c8239309a939d43e0ad704"
-dependencies = [
- "nu-protocol",
-]
+checksum = "202ce25889336061efea24e69d4e0de7147c15fd9892cdd70533500d47db8364"
 
 [[package]]
 name = "nu-parser"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "daac6d76c123d2534bcbc67ed065c4a78a54cf034e09332ed648a85339c11f91"
+checksum = "cb0591ef4d4989c1930863d9d17d8fd2d70b03ec2d9caeca067e9626e05c49d9"
 dependencies = [
  "bytesize",
  "chrono",
@@ -984,9 +981,9 @@ dependencies = [
 
 [[package]]
 name = "nu-path"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e3a55f26e42d1f98fbb4f41fa4fcc7dee1f61f13c5eabda5ca90e78825b2fa"
+checksum = "41c68c7c06898a5c4c9f10038da63759661cb8ac8f301ce7d159173a595c8258"
 dependencies = [
  "dirs",
  "omnipath",
@@ -996,9 +993,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f35f2290c077441edfde50745b501ba5ffad11217d5d01168cf1ab1b0e4c03d"
+checksum = "e00d2ccb35a1206c51740bea63b0deb72dc4c34ca6ceae6feac95f84d68370d2"
 dependencies = [
  "log",
  "nix",
@@ -1007,14 +1004,14 @@ dependencies = [
  "nu-plugin-protocol",
  "nu-protocol",
  "nu-utils",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "nu-plugin-core"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ba6f1d1c7f6ca9852c26e8e65a0f530b8fa3a1237a6c62de089ccaf6c1645fe"
+checksum = "30e416e6de2b62925ffc1924740a0e5340316a1630af3d2490d513bcb1f94e94"
 dependencies = [
  "interprocess",
  "log",
@@ -1028,9 +1025,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-engine"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc79cff665e4434153c97bd7065608f6649cf3a45cb1576d39a58a111c87c9f"
+checksum = "14fb214ba23829ebfe61b9a5e0688cd5620922438d7d76a6f6b3e1151d07e82a"
 dependencies = [
  "log",
  "nu-engine",
@@ -1045,9 +1042,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-protocol"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88bef165a59909561b349fb3eda7e16afae8f8d06d6c99527b4545c086b51f87"
+checksum = "be7edbdee451bb29150b5e8184660d79d0c0801a6748b9f712b758cb78110305"
 dependencies = [
  "nu-protocol",
  "nu-utils",
@@ -1059,9 +1056,9 @@ dependencies = [
 
 [[package]]
 name = "nu-plugin-test-support"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b913effb3fc1b17338a9d3dacddd81ec907a65c94fbd050685366d60d4a773"
+checksum = "b8acb62c21fd980e467162bc17a4e93a8435e28249256b52e58718278149978d"
 dependencies = [
  "nu-ansi-term",
  "nu-cmd-lang",
@@ -1077,9 +1074,9 @@ dependencies = [
 
 [[package]]
 name = "nu-protocol"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca35b5860d171e8e0994d42373f62fc99fb7a0b205e5d8a38897e2869d5f6ab7"
+checksum = "ab657b1947f1fad3c5052cb210fa311744736a4800a966ae21c4bc63de7c60ab"
 dependencies = [
  "brotli",
  "bytes",
@@ -1096,6 +1093,7 @@ dependencies = [
  "miette",
  "nix",
  "nu-derive-value",
+ "nu-glob",
  "nu-path",
  "nu-system",
  "nu-utils",
@@ -1106,7 +1104,7 @@ dependencies = [
  "serde_json",
  "strum",
  "strum_macros",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
  "typetag",
  "web-time",
  "windows-sys 0.48.0",
@@ -1114,9 +1112,9 @@ dependencies = [
 
 [[package]]
 name = "nu-system"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70bb9b1c59acd274bd36b4879e1e03491a3ee2f24689a9070c66fbd8aed23b27"
+checksum = "f47094aaab4f1e3a86c3960400d82a50fcabde907f964ae095963ec95669577a"
 dependencies = [
  "chrono",
  "itertools",
@@ -1134,9 +1132,9 @@ dependencies = [
 
 [[package]]
 name = "nu-utils"
-version = "0.103.0"
+version = "0.104.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f01345a3c94f75397020250286c536e1b306cb714b2931c1a1c9a3318254793"
+checksum = "327999b774d78b301a6b68c33d312a1a8047c59fb8971b6552ebf823251f1481"
 dependencies = [
  "crossterm",
  "crossterm_winapi",
@@ -1620,13 +1618,14 @@ dependencies = [
 
 [[package]]
 name = "shadow-rs"
-version = "0.38.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ec14cc798c29f4bf74a6c4299c657c04d4e9fba03875c1f0eec569af03aed89"
+checksum = "6d5625ed609cf66d7e505e7d487aca815626dc4ebb6c0dd07637ca61a44651a6"
 dependencies = [
  "const_format",
  "is_debug",
  "time",
+ "tzdb",
 ]
 
 [[package]]
@@ -1825,11 +1824,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -1845,9 +1844,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1936,6 +1935,32 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tz-rs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1450bf2b99397e72070e7935c89facaa80092ac812502200375f1f7d33c71a1"
+
+[[package]]
+name = "tzdb"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2ea5956f295449f47c0b825c5e109022ff1a6a53bb4f77682a87c2341fbf5"
+dependencies = [
+ "iana-time-zone",
+ "tz-rs",
+ "tzdb_data",
+]
+
+[[package]]
+name = "tzdb_data"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c4c81d75033770e40fbd3643ce7472a1a9fd301f90b7139038228daf8af03ec"
+dependencies = [
+ "tz-rs",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,9 +33,9 @@ default = [
 ]
 
 [dependencies]
-nu-cmd-base = "0.103.0"
-nu-plugin = "0.103.0"
-nu-protocol = "0.103.0"
+nu-cmd-base = "0.104.0"
+nu-plugin = "0.104.0"
+nu-protocol = "0.104.0"
 digest = "0.10.7"
 ascon-hash = { version = "0.2.0", optional = true }
 belt-hash = { version = "0.1.1", optional = true }
@@ -88,7 +88,7 @@ tiger = { version = "0.2.1", optional = true }
 whirlpool = { version = "0.10.4", optional = true }
 
 [dev-dependencies]
-nu-plugin-test-support = "0.103.0"
+nu-plugin-test-support = "0.104.0"
 
 [profile.release]
 strip = true


### PR DESCRIPTION
Bumped crate dependencies to 0.104.0. Tested that the crate could build, be added and loaded by Nushell as a plugin. All work as expected.